### PR TITLE
Allow non-bash shells, fix status bar non-reload after commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1404 - 2022-7-13
+### Fixed
+    - Fixed a bug where running commands would not reload the status bar
+### Changed
+    - Allow for running commands in non-BASH shells
+
 ## 1403 - 2022-5-4
 ### Fixed
     - Fixed a bug in `write_welcome()` that caused segfualts when the horizontal screen sized was too small.

--- a/src/command.c
+++ b/src/command.c
@@ -536,7 +536,8 @@ void yed_default_command_sh(int n_args, char **args) {
     buff[0]     = 0;
     cmd_buff[0] = 0;
 
-    strcat(buff, "bash -c '(");
+    strcat(buff, getenv("SHELL"));
+    strcat(buff, " -c '(");
 
     lazy_space = "";
     for (i = 0; i < n_args; i += 1) {
@@ -553,8 +554,7 @@ void yed_default_command_sh(int n_args, char **args) {
     fflush(stdout);
     sys_ret = system(buff);
     (void)sys_ret;
-    printf(TERM_CLEAR_SCREEN);
-    fflush(stdout);
+    yed_clear_screen();
 }
 
 void yed_default_command_sh_silent(int n_args, char **args) {
@@ -567,7 +567,8 @@ void yed_default_command_sh_silent(int n_args, char **args) {
     buff[0]     = 0;
     cmd_buff[0] = 0;
 
-    strcat(buff, "bash -c '(");
+    strcat(buff, getenv("SHELL"));
+    strcat(buff, " -c '(");
 
     lazy_space = "";
     for (i = 0; i < n_args; i += 1) {
@@ -593,10 +594,12 @@ void yed_default_command_less(int n_args, char **args) {
     const char *lazy_space;
     int i;
     int err;
+    const char * shell = getenv("SHELL");
 
     buff[0] = 0;
 
-    strcat(buff, "bash -c '(");
+    strcat(buff, shell);
+    strcat(buff, " -c '(");
 
     lazy_space = "";
     for (i = 0; i < n_args; i += 1) {
@@ -605,15 +608,14 @@ void yed_default_command_less(int n_args, char **args) {
         lazy_space = " ";
     }
 
-    strcpy(cmd_buff, buff + strlen("bash -c '("));
+    strcpy(cmd_buff, buff + strlen(shell) + strlen(" -c '("));
 
     strcat(buff, ") 2>&1 | less -cR'");
 
     printf(TERM_STD_SCREEN);
     fflush(stdout);
     err = system(buff);
-    printf(TERM_ALT_SCREEN);
-    fflush(stdout);
+    yed_clear_screen();
 
     if (err == 0) {
         yed_cprint("%s", cmd_buff);


### PR DESCRIPTION
### Fixed
- Reload whole editor when running commands.  Previously, the status bar would not get reloaded, and end up having visual glitches as a result.
### Changed
- Allow for running commands in non-BASH shells by reading from $SHELL